### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,18 +1,18 @@
 play-deliver
 ============
-.. image:: https://pypip.in/version/playdeliver/badge.svg?text=version
+.. image:: https://img.shields.io/pypi/v/playdeliver.svg?label=version
     :target: https://pypi.python.org/pypi/playdeliver/
     :alt: Latest Version
 
-.. image:: https://pypip.in/license/playdeliver/badge.svg
+.. image:: https://img.shields.io/pypi/l/playdeliver.svg
     :target: https://pypi.python.org/pypi/playdeliver/
     :alt: License
 
-.. image:: https://pypip.in/py_versions/playdeliver/badge.svg
+.. image:: https://img.shields.io/pypi/pyversions/playdeliver.svg
     :target: https://pypi.python.org/pypi/playdeliver/
     :alt: Supported Python versions
 
-.. image:: https://pypip.in/status/playdeliver/badge.svg
+.. image:: https://img.shields.io/pypi/status/playdeliver.svg
     :target: https://pypi.python.org/pypi/playdeliver/
     :alt: Development Status
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20playdeliver))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `playdeliver`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.